### PR TITLE
[BUGFIX] - bin folder now added under addons directory

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -158,6 +158,7 @@ checkJarsPalettes()
    				extract $name
 				mkdir -p tibco.home/addons/runtime/plugins/ && mv runtime/plugins/* "$_"
 				mkdir -p tibco.home/addons/lib/ && mv lib/* "$_"/${name##*/}.ini
+				mkdir -p tibco.home/addons/bin/ && mv bin/* "$_"
 			fi
 		done
 	fi


### PR DESCRIPTION
Add ability to copy bin folder from bwce_runtime zip file.

Changes:

- Added support for bin folder in case of CF as well. Earlier, this change was ported for docker only.