### PR TITLE
 Fix to suppress the errors when the bin folder does not exist in the plugin runtime zip

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -159,7 +159,7 @@ checkJarsPalettes()
 				mkdir -p tibco.home/addons/runtime/plugins/ && mv runtime/plugins/* "$_"
 				mkdir -p tibco.home/addons/lib/ && mv lib/*.ini "$_"${name##*/}.ini
 				mkdir -p tibco.home/addons/lib/ && mv lib/*.jar "$_" 2> /dev/null || true
-				mkdir -p tibco.home/addons/bin/ && mv bin/* "$_"
+				mkdir -p tibco.home/addons/bin/ && mv bin/* "$_" 2> /dev/null || true
 			fi
 		done
 	fi


### PR DESCRIPTION
- When a plugin runtime zip does not have bin folder, trying to move the contents of bin folder will throw an error as the folder does not exist and therefore suppressing that error as that is expected behavior.