### PR TITLE
Using 'cf routes' command to get route name

### DIFF
--- a/test/testBuildpack.sh
+++ b/test/testBuildpack.sh
@@ -19,8 +19,10 @@ echo "***** Starting BWCE Sanity *****"
 
 echo "***** Pushing HTTP Greetings App to CF *****"
 appName=`grep -E "name:" manifest.yml | cut -d ':' -f 2 | sed 's/^ *//g' | sed 's/ *$//g'`
-URL=`cf push -f manifest.yml -b $1 | grep "urls:" | cut -d ' ' -f 2`
+echo "cf push -f manifest.yml -b $1"
+cf push -f manifest.yml -b $1
 sleep 5
+URL=`cf routes | grep "${appName}$" | awk '{print $2 "." $3}'`
 a=$(curl "http://$URL/greetings/")
 BWCE_MESSAGE=`grep -E "RESPONSE_MESSAGE:" manifest.yml | cut -d ':' -f 2 | sed 's/^ *//g' | sed 's/ *$//g' `
 if [ "${a}" = "Greetings from $BWCE_MESSAGE" ]; then


### PR DESCRIPTION
Instead of parsing the output of 'cf push' command to get the new route(url), use 'cf routes' command.

The output of 'cf push' has changed when compared between cf cli versions 6.26 and 6.34.
The 6.26 was returning it as 'urls:' where as 6.34 gives it as 'routes:'