### PR TITLE
Changes to handle custom logback.xml

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -386,6 +386,16 @@ mv /tmp/bwapp.ear tibco.home/bw*/*/bin/
 logback=tibco.home/bw*/*/config/logback.xml
 appnodeConfigFile=tibco.home/bw*/*/config/appnode_config.ini
 
+if [[ ${CUSTOM_LOGBACK} ]]; then
+	         logback_custom=$BUILD_PACK_DIR/resources/addons/custom-logback/logback.xml
+		 if [ -e ${logback_custom} ]; then
+			cp ${logback} `ls $logback`.original.bak && cp -f ${logback_custom}  ${logback}  
+			echo "Using Custom Logback file"
+		else
+			echo "Custom Logback file not found. Using the default logback file"
+		fi	
+fi
+
 if [[ ${BW_LOGLEVEL} && "${BW_LOGLEVEL,,}"="debug" ]]; then
 	if [ -e ${logback} ]; then
 		sed -i.bak "/<root/ s/\".*\"/\"$BW_LOGLEVEL\"/Ig" $logback


### PR DESCRIPTION
-Made changes to be able to use custom logback.xml.
-The custom logback.xml file needs to be placed in the resources/addons/custom_logback folder and should have the name logback.xml
-If the environment variable CUSTOM_LOGBACK is provided, then this file would be used . The default logback file is backed up and the custom logback file is copied and used instead of the default logback.xml.