### PR TITLE
Fix to avoid duplicate values for heap parameters

### DIFF
--- a/resources/prestart.sh
+++ b/resources/prestart.sh
@@ -49,7 +49,9 @@ memoryCalculator()
 		configured_MEM=$((($memory_Number*67+50)/100))
 		thread_Stack=$((memory_Number))
 		JAVA_PARAM="-Xmx"$configured_MEM"M -Xms128M -Xss512K"
-		export BW_JAVA_OPTS=$JAVA_PARAM" "$BW_JAVA_OPTS
+		if [[ ${BW_JAVA_OPTS} && ${BW_JAVA_OPTS} != *"Xm"* ||  -z ${BW_JAVA_OPTS} ]]; then
+			export BW_JAVA_OPTS=$JAVA_PARAM" "$BW_JAVA_OPTS
+		fi
 	fi
 }
 


### PR DESCRIPTION
MEMORY_LIMIT variable is set by default in PCF which invokes the memory calculator function every time. When Java heap parameters are passed as a part of JAVA_OPTS_PARAMs this value needs to be picked instead of the dynamically calculated values. Added a check to use user provided values instead of the dynamically calculated values.